### PR TITLE
Enforce strict regex-based hostname validation

### DIFF
--- a/lib/processors/ad_list_processor.rb
+++ b/lib/processors/ad_list_processor.rb
@@ -5,6 +5,12 @@ require_relative '../utils/logger'
 
 module Processors
   class AdListProcessor
+    HOSTNAME_REGEX = /\A
+      (?=.{1,253}\z) # Overall length up to 253 chars
+      [a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])? # One hostname label
+      (?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)* # Additional labels
+    \z/x.freeze
+
     def self.download_ad_list(url) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       Utils::Log.logger.info("Downloading ad list from #{url}...")
       uri = URI.parse(url)
@@ -21,6 +27,10 @@ module Processors
       end
     end
 
+    def self.valid_hostname?(hostname)
+      hostname.match?(HOSTNAME_REGEX)
+    end
+
     def self.process_ad_list(ad_list_content, exclusions) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       Utils::Log.logger.info('Processing ad list content...')
       Utils::Log.logger.debug("Ad list content length: #{ad_list_content.length}, exclusions: #{exclusions}")
@@ -30,21 +40,28 @@ module Processors
         original_line = line.strip
         next if original_line.empty? || original_line.start_with?('#')
 
+        # Remove comments
         line = original_line.split('#').first.strip
 
-        case line
-        when /^(\d{1,3}\.){3}\d{1,3}\s+(.+)$/
-          hostname = ::Regexp.last_match(2).strip
-          next if hostname =~ /^(\d{1,3}\.){3}\d{1,3}$/
+        hostname = case line
+                   when /^(\d{1,3}\.){3}\d{1,3}\s+(.+)$/
+                     candidate = ::Regexp.last_match(2).strip
+                     candidate =~ /^(\d{1,3}\.){3}\d{1,3}$/ ? nil : candidate
+                   when /^::1\s+(.+)$/
+                     ::Regexp.last_match(1).strip
+                   when /^\S+$/
+                     line
+                   else
+                     Utils::Log.logger.warn("Unrecognized line in ad list: #{original_line}")
+                     nil
+                   end
 
-          hostnames << hostname unless exclusions.include?(hostname)
-        when /^::1\s+(.+)$/
-          hostname = ::Regexp.last_match(1).strip
-          hostnames << hostname unless exclusions.include?(hostname)
-        when /^\S+$/
-          hostnames << line unless exclusions.include?(line)
+        next if hostname.nil? || exclusions.include?(hostname)
+
+        if valid_hostname?(hostname)
+          hostnames << hostname
         else
-          Utils::Log.logger.warn("Unrecognized line in ad list: #{original_line}")
+          Utils::Log.logger.warn("Invalid hostname encountered: #{hostname}")
         end
       end
 


### PR DESCRIPTION
Previously, invalid hostnames (e.g. "www.") were passed through unverified, causing issues when pushing these records to Cloudflare Zero Trust lists (which do not support invalid hostnames). This change introduces an RFC-compliant regex check to ensure only valid hostnames are included.